### PR TITLE
Look for DL_LOAD_PATH in the right place in julia 0.4.

### DIFF
--- a/src/Homebrew.jl
+++ b/src/Homebrew.jl
@@ -18,6 +18,8 @@ const BREW_URL = "https://github.com/Homebrew/homebrew.git"
 const BREW_BRANCH = "master"
 const BOTTLE_SERVER = "https://juliabottles.s3.amazonaws.com"
 
+const DL_LOAD_PATH = VERSION >= v"0.4.0-" ? Libdl.DL_LOAD_PATH : Base.DL_LOAD_PATH
+
 
 function init()
     # Let's see if Homebrew is installed.  If not, let's do that first!


### PR DESCRIPTION
This fixes an error I'm getting on julia 0.4 master, since `DL_LOAD_PATH` was moved to the `Libdl` namespace.