### PR TITLE
enable force linking

### DIFF
--- a/src/Homebrew.jl
+++ b/src/Homebrew.jl
@@ -314,7 +314,7 @@ function add(pkg::AbstractString)
         end
 
         # Finally, if we need to, link it in
-        quiet_run(`$brew link $pkg`)
+        quiet_run(`$brew link --force $pkg`)
     end
 end
 


### PR DESCRIPTION
This allows installation of keg-only packages, so we can use newer versions than the OS supplied ones

(I wanted to use the homebrew SQLite, which enables more options than the OS supplied one)