### PR TITLE
Use newer BREW_URL and `brew update` instead of libgit2

### DIFF
--- a/src/Homebrew.jl
+++ b/src/Homebrew.jl
@@ -16,7 +16,11 @@ const brew_prefix = abspath(joinpath(dirname(@__FILE__),"..","deps", "usr"))
 const brew_exe = joinpath(brew_prefix,"bin","brew")
 const tappath = joinpath(brew_prefix,"Library","Taps","staticfloat","homebrew-juliadeps")
 
-const BREW_URL = "https://github.com/Homebrew/homebrew.git"
+if VERSION < v"0.5.0-dev+522"
+    const BREW_URL = "https://github.com/Homebrew/homebrew.git"
+else
+    const BREW_URL = "https://github.com/Homebrew/brew.git"
+end
 const BREW_BRANCH = "master"
 const BOTTLE_SERVER = "https://juliabottles.s3.amazonaws.com"
 

--- a/src/Homebrew.jl
+++ b/src/Homebrew.jl
@@ -156,34 +156,6 @@ if VERSION < v"0.5.0-dev+522"
 else
     function update()
         brew(`update`)
-#=
-        repo = LibGit2.GitRepo(brew_prefix)
-        remote = LibGit2.get(LibGit2.GitRemote, repo, "origin")
-#        LibGit2.fetch(remote,[BREW_BRANCH])
-#        TAP_BRANCH = LibGit2.revparseid(repo, tappath)
-#        LibGit2.reset!(repo, TAP_BRANCH, LibGit2.Consts.RESET_HARD)
-        
-        tapsdir = joinpath(brew_prefix,"Library","Taps")
-        namespaces = readdir(tapsdir)
-        ns_taps = [[joinpath(tapsdir, ns, tap) for tap in readdir(joinpath(tapsdir, ns))] for ns in namespaces]
-        taps = vcat(ns_taps...)
-
-        # Update each tap, one after another
-        for tap in taps
-            tapname = basename(tap)
-            @show namespace = basename(dirname(tap))
-            println("Updating tap $tapname")
-            brew(`tap --full $namespace/$tapname`)
-            @show taprepo = LibGit2.GitRepo(tap)
-            #@show tapremote = LibGit2.get(LibGit2.GitRemote, taprepo, "origin")
-            @show LibGit2.fetch(taprepo) #, remote="origin")
-            #@show refspec = LibGit2.fetch_refspecs(tapremote)
-            #@show LibGit2.fetch(tapremote,refspec)
-            @show TAP_BRANCH = LibGit2.branch(taprepo)
-            @show TAP_OBJ = LibGit2.revparse(taprepo, "origin/$TAP_BRANCH")
-            @show LibGit2.reset!(taprepo, TAP_OBJ, LibGit2.Consts.RESET_HARD)
-        end
-=#
         upgrade()
     end
 end


### PR DESCRIPTION
There were several issues with https://github.com/JuliaLang/Homebrew.jl/pull/106#issuecomment-204593240, taps were not actually getting updated, libgit2 doesn't support shallow clones (the cause of the "Object not found" errors), and legacy homebrew doesn't support unshallowing already-installed taps. We might want to make this change even on 0.4, but that may be a bit riskier than staying on legacy homebrew there. Though I suppose it means we won't get updated homebrew-core formulae since we're only updating via git instead of whatever migration magic `brew update` automatically handles.

I can't tell for sure whether or not legacy homebrew will automatically tap the new homebrew-core...