### PR TITLE
change homebrew url

### DIFF
--- a/src/Homebrew.jl
+++ b/src/Homebrew.jl
@@ -14,7 +14,7 @@ const brew_prefix = abspath(joinpath(dirname(@__FILE__),"..","deps", "usr"))
 const brew_exe = joinpath(brew_prefix,"bin","brew")
 const tappath = joinpath(brew_prefix,"Library","Taps","staticfloat","homebrew-juliadeps")
 
-const BREW_URL = "https://github.com/Homebrew/homebrew.git"
+const BREW_URL = "https://github.com/Homebrew/brew.git"
 const BREW_BRANCH = "master"
 const BOTTLE_SERVER = "https://juliabottles.s3.amazonaws.com"
 


### PR DESCRIPTION
note that I made a new prelibgit2 branch for this and made it the default on github.
master (also saved as libgit2dev, currently equivalent) has libgit2 work on it
which doesn't totally work yet so shouldn't be tagged. this may not be able to do
migrations of existing installs properly, but I think those are hosed right now anyway