### PR TITLE
Remove some code and docstring duplication

### DIFF
--- a/src/private_API.jl
+++ b/src/private_API.jl
@@ -5,9 +5,8 @@
 # location of files within the Cellar
 
 const tappath = joinpath(brew_prefix,"Library","Taps","staticfloat","homebrew-juliadeps")
-#const BREW_URL = "https://github.com/Homebrew/brew"
-const BREW_URL = "https://github.com/staticfloat/brew"
-const BREW_BRANCH = "sf/no_clt_no_problem"
+const BREW_URL = "https://github.com/Homebrew/brew"
+const BREW_BRANCH = "master"
 const BOTTLE_SERVER = "https://juliabottles.s3.amazonaws.com"
 
 


### PR DESCRIPTION
apparently the form of empty methods I was originally using was a new 0.5 feature, now fixed

last of my review changes for #113 

Will want to verify that the docstrings and dispatch are all properly visible when generating many of the repeated BrewPkg signatures in macros like this.