### PR TITLE
Improvements

### DIFF
--- a/src/bindeps_integration.jl
+++ b/src/bindeps_integration.jl
@@ -25,6 +25,14 @@ function package_available(p::HB)
     # For each package, see if we can get info about it.  If not, fail out
     for pkg in pkgs
         try
+            # First, tap the package if we need to
+            path, tap_path = formula_tap(pkg)
+
+            if !isempty(tap_path)
+                tap(tap_path)
+            end
+
+            # Next, ask for info on that package
             info(pkg)
         catch
             return false

--- a/src/translation.jl
+++ b/src/translation.jl
@@ -204,6 +204,8 @@ function translate_formula(name::AbstractString; verbose::Bool=false)
         end
         if new_obj[k] != obj[k]
             warn("New JSON object doesn't agree with old in key \"$k\"; we screwed something up while translating $name")
+            warn("Original formula: $(obj[k])")
+            warn("Translated formula: $(new_obj[k])")
             delete_translated_formula(override_name; verbose=verbose)
             return name
         end

--- a/src/translation.jl
+++ b/src/translation.jl
@@ -199,7 +199,7 @@ function translate_formula(name::AbstractString; verbose::Bool=false)
     # for a few important keys such as "bottle" and "full_name"
     for k in keys(new_obj)
         # Skip these keys, they always different
-        if k in ["bottle", "versions", "full_name", "aliases", "outdated"]
+        if k in ["bottle", "versions", "full_name", "aliases", "outdated", "linked_keg"]
             continue
         end
         if new_obj[k] != obj[k]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -58,14 +58,19 @@ end
 @test Homebrew.has_bottle("ld64") == false
 
 # Test that we can translate properly
+info("Translation should pass:")
 @test Homebrew.translate_formula("gettext"; verbose=true) == "staticfloat/juliatranslated/gettext"
+info("Translation should fail because it has no bottles:")
 @test Homebrew.translate_formula("ack"; verbose=true) == "ack"
+info("Translation should fail because it is special-cased in staticfloat/juliadeps:")
 @test Homebrew.translate_formula("fontconfig"; verbose=true) == "staticfloat/juliadeps/fontconfig"
 
 # Make sure translation works properly with other taps
 Homebrew.delete_translated_formula("Homebrew/science/hdf5"; verbose=true)
-@test Homebrew.translate_formula("Homebrew/science/hdf5") == "staticfloat/juliatranslated/hdf5"
-# Do it a second time so we can get coverage of practiing that particular method of bailing out
+info("Translation should pass because we just deleted hdf5 from translation cache:")
+@test Homebrew.translate_formula("Homebrew/science/hdf5"; verbose=true) == "staticfloat/juliatranslated/hdf5"
+info("Translation should fail because hdf5 has already been translated:")
+# Do it a second time so we can get coverage of practicing that particular method of bailing out
 Homebrew.translate_formula(Homebrew.info("Homebrew/science/hdf5"); verbose=true)
 
 # Test more miscellaneous things
@@ -73,6 +78,7 @@ fontconfig = Homebrew.info("staticfloat/juliadeps/fontconfig")
 @test Homebrew.formula_path(fontconfig) == joinpath(Homebrew.tappath, "fontconfig.rb")
 @test !isempty(Homebrew.read_formula("xz"))
 @test !isempty(Homebrew.read_formula(fontconfig))
+info("add() should fail because this actually isn't a package name:")
 @test_throws ArgumentError Homebrew.add("thisisntapackagename")
 
 Homebrew.unlink(pkgconfig)


### PR DESCRIPTION
Tap things automatically when BinDeps comes calling, widen our blacklist of things to ignore when checking to see if a formula transformation worked, and improve testing output to make it a little more apparent when things should be failing and when they shouldn't be.

The reason I have this blacklist and inspect the JSON objects is out of an overabundance of caution:  If the check fails, it will attempt to compile from source, and alerts the user to come complain to us about it so that we can look and ensure that everything is still on the up-and-up.  `linked_keg` could differ if the user has an older version installed and is installing a newer version now.  I've updated the code to actually print the difference now, so we should be able to see exactly what differs.