### PR TITLE
Fix "Diamond of death" bug in translation machinery

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -253,7 +253,7 @@ function info(name::AbstractString)
 end
 
 """
-`direct_deps(pkg::Union{AbstractString,BrewPkg})`
+`direct_deps(pkg::Union{AbstractString,BrewPkg}; build_deps::Bool=false)`
 
 Return a list of all direct dependencies of `pkg` as a `Vector{BrewPkg}`
 If `build_deps` is `true` include formula depependencies marked as `:build`.
@@ -278,7 +278,7 @@ function direct_deps(pkg::BrewPkg; build_deps::Bool=false)
 end
 
 """
-`deps_tree(pkg::Union{AbstractString,BrewPkg})`
+`deps_tree(pkg::Union{AbstractString,BrewPkg}; build_deps::Bool=false)`
 
 Return a dictionary mapping every dependency (both direct and indirect) of `pkg`
 to a `Vector{BrewPkg}` of all of its dependencies.  Used in `deps_sorted()`.

--- a/src/API.jl
+++ b/src/API.jl
@@ -253,24 +253,28 @@ function info(name::AbstractString)
 end
 
 """
-`deps(pkg::Union{AbstractString,BrewPkg})`
+`direct_deps(pkg::Union{AbstractString,BrewPkg})`
 
 Return a list of all direct dependencies of `pkg` as a `Vector{BrewPkg}`
+If `build_deps` is `true` include formula depependencies marked as `:build`.
 """
-function deps(pkg::StringOrPkg) end
+function direct_deps(pkg::StringOrPkg; build_deps::Bool=false) end
 
-function deps(name::AbstractString)
+function direct_deps(name::AbstractString; build_deps::Bool=false)
     obj = json(name)
 
     # Iterate over all dependencies, removing optional and build dependencies
     dependencies = String[dep for dep in obj["dependencies"]]
     dependencies = filter(x -> !(x in obj["optional_dependencies"]), dependencies)
-    dependencies = filter(x -> !(x in obj["build_dependencies"]), dependencies)
+
+    if !build_deps
+        dependencies = filter(x -> !(x in obj["build_dependencies"]), dependencies)
+    end
     return info(dependencies)
 end
 
-function deps(pkg::BrewPkg)
-    return deps(fullname(pkg))
+function direct_deps(pkg::BrewPkg; build_deps::Bool=false)
+    return direct_deps(fullname(pkg); build_deps=build_deps)
 end
 
 """
@@ -278,14 +282,16 @@ end
 
 Return a dictionary mapping every dependency (both direct and indirect) of `pkg`
 to a `Vector{BrewPkg}` of all of its dependencies.  Used in `deps_sorted()`.
-"""
-function deps_tree(pkg::StringOrPkg) end
 
-function deps_tree(name::AbstractString)
+If `build_deps` is `true` include formula depependencies marked as `:build`.
+"""
+function deps_tree(pkg::StringOrPkg; build_deps::Bool=false) end
+
+function deps_tree(name::AbstractString; build_deps::Bool=false)
     # First, get all the knowledge we need about dependencies
     deptree = Dict{String,Vector{BrewPkg}}()
 
-    pending_deps = deps(name)
+    pending_deps = direct_deps(name; build_deps=build_deps)
     completed_deps = Set(String[])
     while !isempty(pending_deps)
         # Temporarily move pending_deps over to curr_pending_deps
@@ -294,7 +300,7 @@ function deps_tree(name::AbstractString)
 
         # Iterate over these currently pending deps, adding new ones to pending_deps
         for pkg in curr_pending_deps
-            deptree[fullname(pkg)] = deps(pkg)
+            deptree[fullname(pkg)] = direct_deps(pkg; build_deps=build_deps)
             push!(completed_deps, fullname(pkg))
             for dpkg in deptree[fullname(pkg)]
                 if !(fullname(dpkg) in completed_deps)
@@ -307,8 +313,8 @@ function deps_tree(name::AbstractString)
     return deptree
 end
 
-function deps_tree(pkg::BrewPkg)
-    return deps_tree(fullname(pkg))
+function deps_tree(pkg::BrewPkg; build_deps::Bool=false)
+    return deps_tree(fullname(pkg); build_deps=build_deps)
 end
 
 """
@@ -348,15 +354,17 @@ function insert_after_dependencies(tree::Dict, sorted_deps::Vector{BrewPkg}, nam
 end
 
 """
-`deps_sorted(pkg::Union{AbstractString,BrewPkg})`
+`deps_sorted(pkg::Union{AbstractString,BrewPkg}; build_deps::Bool)`
 
 Return a sorted `Vector{BrewPkg}` of all dependencies (direct and indirect) such
 that each entry in the list appears after all of its own dependencies.
-"""
-function deps_sorted(pkg::StringOrPkg) end
 
-function deps_sorted(name::AbstractString)
-    tree = deps_tree(name)
+If `build_deps` is `true` include formula depependencies marked as `:build`.
+"""
+function deps_sorted(pkg::StringOrPkg; build_deps::Bool=false) end
+
+function deps_sorted(name::AbstractString; build_deps::Bool=false)
+    tree = deps_tree(name; build_deps=build_deps)
     sorted_deps = BrewPkg[]
 
     # For each package in the tree, insert it only after all of its dependencies
@@ -369,8 +377,8 @@ function deps_sorted(name::AbstractString)
     return sorted_deps
 end
 
-function deps_sorted(pkg::BrewPkg)
-    return deps_sorted(fullname(pkg))
+function deps_sorted(pkg::BrewPkg; build_deps::Bool=false)
+    return deps_sorted(fullname(pkg); build_deps=build_deps)
 end
 
 """
@@ -384,9 +392,21 @@ and forcing `cellar :any` into the formulae.
 function add(pkg::StringOrPkg; verbose::Bool=false) end
 
 function add(name::AbstractString; verbose::Bool=false)
-    # Begin by translating `name` and all dependencies
+    # Begin by translating all dependencies of `name`, including :build deps.
+    # We need to translate :build deps so that we don't run into the diamond of death
+    sorted_deps = AbstractString[]
+    runtime_deps = deps_sorted(name)
+    for dep in deps_sorted(name; build_deps=true)
+        translated_dep = translate_formula(dep; verbose=verbose)
+
+        # Collecft the translated runtime_deps into sorted_deps
+        if dep in runtime_deps
+            push!(sorted_deps, translated_dep)
+        end
+    end
+
+    # Translate the actual formula we're interested in
     name = translate_formula(name; verbose=verbose)
-    sorted_deps = [translate_formula(dep; verbose=verbose) for dep in deps_sorted(name)]
 
     # Push `name` onto the end of `sorted_deps` so we have one list of things to install
     push!(sorted_deps, name)
@@ -590,8 +610,4 @@ function versioninfo(;verbose=false)
     println("$(length(translated_pkgs)) auto-translated packages installed:")
     println(join([x.name for x in translated_pkgs], ", "))
     println()
-
-    juliadeps_pkgs = filter(x -> x.tap == "staticfloat/juliadeps", installed_pkgs)
-    println("$(length(juliadeps_pkgs)) juliadeps packages installed:")
-    println(join([x.name for x in juliadeps_pkgs], ", "))
 end

--- a/src/translation.jl
+++ b/src/translation.jl
@@ -191,13 +191,13 @@ function translate_formula(name::AbstractString; verbose::Bool=false)
             if verbose
                 println("translation: replacing dependency $dep_name because it's been translated before")
             end
-            new_name = tapname * dep_name
+            new_name = "$(auto_tapname)/$(dep_name)"
             offset = m.offsets[1]
 
             start_idx = offset-1+adjustment
             stop_idx = offset+length(dep_name)+adjustment
             formula = formula[1:start_idx] * new_name * formula[stop_idx:end]
-            adjustment += length(tapname)
+            adjustment += length(auto_tapname)
         end
     end
 

--- a/src/util.jl
+++ b/src/util.jl
@@ -26,6 +26,9 @@ function update_env()
     # user-maintained Homebrew installations, and multiple users can use it at once
     ENV["HOMEBREW_CACHE"] = joinpath(ENV["HOME"],"Library/Caches/Homebrew.jl/")
 
+    # We invoke `brew` a lot, let's disable automatic updates since we do those explicitly
+    ENV["HOMEBREW_NO_AUTO_UPDATE"] = "1"
+
     # If we have `git` installed from Homebrew, add its environment variables
     if isfile(joinpath(brew_prefix,"bin","git"))
         ENV["GIT_EXEC_PATH"] = joinpath(brew_prefix,"opt","git","libexec","git-core")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -43,15 +43,15 @@ info("$(pkgconfig) installed to: $(Homebrew.prefix(pkgconfig))")
 @test Homebrew.linked(pkgconfig) == true
 
 # Test dependency inspection
-@test Homebrew.deps("pkg-config") == []
-@test Homebrew.deps(pkgconfig) == []
-@test Homebrew.deps("nettle") == [Homebrew.info("gmp")]
-@test Homebrew.deps(Homebrew.info("nettle")) == [Homebrew.info("gmp")]
+@test Homebrew.direct_deps("pkg-config") == []
+@test Homebrew.direct_deps(pkgconfig) == []
+@test Homebrew.direct_deps("nettle") == [Homebrew.info("gmp")]
+@test Homebrew.direct_deps(Homebrew.info("nettle")) == [Homebrew.info("gmp")]
 
 # Run through our sorted deps routines, ensuring that everything is sorted
 sortdeps = Homebrew.deps_sorted("pango")
 for idx in 1:length(sortdeps)
-    for dep in Homebrew.deps(sortdeps[idx])
+    for dep in Homebrew.direct_deps(sortdeps[idx])
         depidx = findfirst(x -> (x.name == dep.name), sortdeps)
         @test depidx != 0
         @test depidx < idx
@@ -73,8 +73,6 @@ info("Translation should pass:")
 @test Homebrew.translate_formula("gettext"; verbose=true) == "staticfloat/juliatranslated/gettext"
 info("Translation should fail because it has no bottles:")
 @test Homebrew.translate_formula("ack"; verbose=true) == "ack"
-info("Translation should fail because it is special-cased in staticfloat/juliadeps:")
-@test Homebrew.translate_formula("fontconfig"; verbose=true) == "staticfloat/juliadeps/fontconfig"
 
 # Make sure translation works properly with other taps
 Homebrew.delete_translated_formula("Homebrew/science/hdf5"; verbose=true)


### PR DESCRIPTION
It was possible to trigger compilation of formulae that were listed as `:build` dependencies if there was a complex relationship between the top-level dependencies and the lower ones.  We fix this by adding to the translation machinery a simple regex replacement that replaces depends_on statements with previously translated formulae paths, simplifying the complex relationships.

The long and the short of this change is that a lot more formulae will be translated (having a `cellar :any` bottle isn't enough to get translation to skip you anymore).

I also got rid of the JSON check, because it has lived past the end of its usefulness.