### PR TITLE
simplify .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,10 @@
 language: julia
-matrix:
-    include:
-        - os: osx
-          osx_image: xcode7.3
-          julia: 0.4
-        - os: osx
-          osx_image: xcode7.3
-          julia: 0.5
-        - os: osx
-          osx_image: xcode7.3
-          julia: nightly
+os: osx
+osx_image: xcode7.3
+julia:
+    - 0.4
+    - 0.5
+    - nightly
 notifications:
     email: false
 after_success:


### PR DESCRIPTION
the only reason base julia uses the complicated matrix include setup
is to avoid doing i686 builds on osx, which is irrelevant here